### PR TITLE
Adding subscription Id for cases where more than one subscription exists in tenant

### DIFF
--- a/Challenge01-AzureAPIforFHIR/ReadMe.md
+++ b/Challenge01-AzureAPIforFHIR/ReadMe.md
@@ -77,7 +77,7 @@ Active Directory is usually locked down at many customers as a securtiy best pra
    >   ```powershell
    >   Clear-AzContext
    >   Connect-AzAccount
-   >   Set-AzContext -TenantId **{YourPrimary or Resoruce ADTenantID}**
+   >   Set-AzContext -TenantId **{YourPrimary or Resource ADTenantID}** -SubscriptionId "Your Subscription ID"
    >   Get-AzContext
    >   ```
 


### PR DESCRIPTION
The instructions as it stands now does not update the correct subscription to use with the Set-AzContext command. In my case, my primary tenant has multiple subscriptions. Making this command more specific to select a subscription.
